### PR TITLE
Add missing auth id(0x02~0x05)

### DIFF
--- a/c/ckb_identity.h
+++ b/c/ckb_identity.h
@@ -25,7 +25,7 @@
 #define MAX_PREIMAGE_SIZE 1024
 #define MESSAGE_HEX_LEN 64
 
-const char BTC_PREFIX[] = "CKB (Bitcoin Layer-2) transaction: 0x";
+const char BTC_PREFIX[] = "CKB (Bitcoin Layer) transaction: 0x";
 // BTC_PREFIX_LEN = 35
 const size_t BTC_PREFIX_LEN = sizeof(BTC_PREFIX) - 1;
 

--- a/c/conversion.h
+++ b/c/conversion.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2014-2018 The Bitcoin Core developers
+ * Distributed under the MIT software license, see the accompanying
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.
+ *
+ * only used on little endian
+ */
+
+#ifndef CONVERSION_H
+#define CONVERSION_H
+
+#include <stdint.h>
+#include <string.h>
+
+uint32_t static inline bswap_32(uint32_t x) {
+  return (((uint32_t)(x)&0xff000000) >> 24) |
+         (((uint32_t)(x)&0x00ff0000) >> 8) | (((uint32_t)(x)&0x0000ff00) << 8) |
+         (((uint32_t)(x)&0x000000ff) << 24);
+}
+
+uint64_t static inline bswap_64(uint64_t x) {
+  return (((uint64_t)(x)&0xff00000000000000ull) >> 56) |
+         (((uint64_t)(x)&0x00ff000000000000ull) >> 40) |
+         (((uint64_t)(x)&0x0000ff0000000000ull) >> 24) |
+         (((uint64_t)(x)&0x000000ff00000000ull) >> 8) |
+         (((uint64_t)(x)&0x00000000ff000000ull) << 8) |
+         (((uint64_t)(x)&0x0000000000ff0000ull) << 24) |
+         (((uint64_t)(x)&0x000000000000ff00ull) << 40) |
+         (((uint64_t)(x)&0x00000000000000ffull) << 56);
+}
+
+uint32_t static inline le32toh_(uint32_t x) { return x; }
+
+uint32_t static inline htole32_(uint32_t x) { return x; }
+
+uint32_t static inline be32toh_(uint32_t x) { return bswap_32(x); }
+
+uint32_t static inline htobe32_(uint32_t x) { return bswap_32(x); }
+
+uint64_t static inline le64toh_(uint64_t x) { return x; }
+
+uint64_t static inline htole64_(uint64_t x) { return x; }
+
+uint32_t static inline be64toh_(uint64_t x) { return bswap_64(x); }
+
+uint64_t static inline htobe64_(uint64_t x) { return bswap_64(x); }
+
+uint32_t static inline ReadLE32(const unsigned char* ptr) {
+  uint32_t x;
+  memcpy((char*)&x, ptr, 4);
+  return le32toh_(x);
+}
+
+void static inline WriteLE32(unsigned char* ptr, uint32_t x) {
+  uint32_t v = htole32_(x);
+  memcpy(ptr, (char*)&v, 4);
+}
+
+uint32_t static inline ReadBE32(const unsigned char* ptr) {
+  uint32_t x;
+  memcpy((char*)&x, ptr, 4);
+  return be32toh_(x);
+}
+
+void static inline WriteBE32(unsigned char* ptr, uint32_t x) {
+  uint32_t v = htobe32_(x);
+  memcpy(ptr, (char*)&v, 4);
+}
+
+void static inline WriteLE64(unsigned char* ptr, uint64_t x) {
+  uint64_t v = htole64_(x);
+  memcpy(ptr, (char*)&v, 8);
+}
+
+uint64_t static inline ReadLE64(const unsigned char* ptr) {
+  uint64_t x;
+  memcpy((char*)&x, ptr, 8);
+  return le64toh_(x);
+}
+
+void static inline WriteBE64(unsigned char* ptr, uint64_t x) {
+  uint64_t v = htobe64_(x);
+  memcpy(ptr, (char*)&v, 8);
+}
+
+uint64_t static inline ReadBE64(const unsigned char* ptr) {
+  uint64_t x;
+  memcpy((char*)&x, ptr, 8);
+  return be64toh_(x);
+}
+
+#endif

--- a/c/omni_lock.c
+++ b/c/omni_lock.c
@@ -136,8 +136,8 @@ bool is_memory_enough(mol_seg_t seg, const uint8_t *cur, uint32_t len) {
 
 // memory layout of args:
 // <identity, 21 bytes> <omni_lock args>
-// <omni_lock flags, 1 byte>  <OMNI cell type id, 32 bytes, optional> <ckb/udt min,
-// 2 bytes, optional> <since, 8 bytes, optional>
+// <omni_lock flags, 1 byte>  <OMNI cell type id, 32 bytes, optional> <ckb/udt
+// min, 2 bytes, optional> <since, 8 bytes, optional>
 int parse_args(ArgsType *args) {
   int err = 0;
   uint8_t script[SCRIPT_SIZE];

--- a/c/ripemd160.h
+++ b/c/ripemd160.h
@@ -1,0 +1,331 @@
+// Copyright (c) 2014-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef RIPEMD160_H
+#define RIPEMD160_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "conversion.h"
+
+typedef struct ripemd160_state__ {
+  uint32_t s[5];
+  unsigned char buf[64];
+  uint64_t bytes;
+} ripemd160_state;
+
+void ripemd160_init(ripemd160_state* S);
+void ripemd160_update(ripemd160_state* S, const unsigned char* data,
+                      size_t len);
+void ripemd160_finalize(ripemd160_state* S, unsigned char hash[20]);
+void ripemd160_reset(ripemd160_state* S);
+
+static uint32_t inline f1(uint32_t x, uint32_t y, uint32_t z) {
+  return x ^ y ^ z;
+}
+uint32_t static inline f2(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & y) | (~x & z);
+}
+static uint32_t inline f3(uint32_t x, uint32_t y, uint32_t z) {
+  return (x | ~y) ^ z;
+}
+static uint32_t inline f4(uint32_t x, uint32_t y, uint32_t z) {
+  return (x & z) | (y & ~z);
+}
+static uint32_t inline f5(uint32_t x, uint32_t y, uint32_t z) {
+  return x ^ (y | ~z);
+}
+
+static uint32_t inline rol(uint32_t x, int i) {
+  return (x << i) | (x >> (32 - i));
+}
+
+static void inline ripemd160_round(uint32_t* a, uint32_t b, uint32_t* c,
+                                   uint32_t d, uint32_t e, uint32_t f,
+                                   uint32_t x, uint32_t k, int r) {
+  *a = rol(*a + f + x + k, r) + e;
+  *c = rol(*c, 10);
+}
+
+static void inline R11(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f1(b, *c, d), x, 0, r);
+}
+static void inline R21(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f2(b, *c, d), x, 0x5A827999ul, r);
+}
+static void inline R31(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f3(b, *c, d), x, 0x6ED9EBA1ul, r);
+}
+static void inline R41(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f4(b, *c, d), x, 0x8F1BBCDCul, r);
+}
+static void inline R51(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f5(b, *c, d), x, 0xA953FD4Eul, r);
+}
+
+static void inline R12(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f5(b, *c, d), x, 0x50A28BE6ul, r);
+}
+static void inline R22(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f4(b, *c, d), x, 0x5C4DD124ul, r);
+}
+static void inline R32(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f3(b, *c, d), x, 0x6D703EF3ul, r);
+}
+static void inline R42(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f2(b, *c, d), x, 0x7A6D76E9ul, r);
+}
+static void inline R52(uint32_t* a, uint32_t b, uint32_t* c, uint32_t d,
+                       uint32_t e, uint32_t x, int r) {
+  ripemd160_round(a, b, c, d, e, f1(b, *c, d), x, 0, r);
+}
+
+/** Perform a RIPEMD-160 transformation, processing a 64-byte chunk. */
+static void ripemd160_transform(uint32_t* s, const unsigned char* chunk) {
+  uint32_t a1 = s[0], b1 = s[1], c1 = s[2], d1 = s[3], e1 = s[4];
+  uint32_t a2 = a1, b2 = b1, c2 = c1, d2 = d1, e2 = e1;
+  uint32_t w0 = ReadLE32(chunk + 0), w1 = ReadLE32(chunk + 4),
+           w2 = ReadLE32(chunk + 8), w3 = ReadLE32(chunk + 12);
+  uint32_t w4 = ReadLE32(chunk + 16), w5 = ReadLE32(chunk + 20),
+           w6 = ReadLE32(chunk + 24), w7 = ReadLE32(chunk + 28);
+  uint32_t w8 = ReadLE32(chunk + 32), w9 = ReadLE32(chunk + 36),
+           w10 = ReadLE32(chunk + 40), w11 = ReadLE32(chunk + 44);
+  uint32_t w12 = ReadLE32(chunk + 48), w13 = ReadLE32(chunk + 52),
+           w14 = ReadLE32(chunk + 56), w15 = ReadLE32(chunk + 60);
+
+  R11(&a1, b1, &c1, d1, e1, w0, 11);
+  R12(&a2, b2, &c2, d2, e2, w5, 8);
+  R11(&e1, a1, &b1, c1, d1, w1, 14);
+  R12(&e2, a2, &b2, c2, d2, w14, 9);
+  R11(&d1, e1, &a1, b1, c1, w2, 15);
+  R12(&d2, e2, &a2, b2, c2, w7, 9);
+  R11(&c1, d1, &e1, a1, b1, w3, 12);
+  R12(&c2, d2, &e2, a2, b2, w0, 11);
+  R11(&b1, c1, &d1, e1, a1, w4, 5);
+  R12(&b2, c2, &d2, e2, a2, w9, 13);
+  R11(&a1, b1, &c1, d1, e1, w5, 8);
+  R12(&a2, b2, &c2, d2, e2, w2, 15);
+  R11(&e1, a1, &b1, c1, d1, w6, 7);
+  R12(&e2, a2, &b2, c2, d2, w11, 15);
+  R11(&d1, e1, &a1, b1, c1, w7, 9);
+  R12(&d2, e2, &a2, b2, c2, w4, 5);
+  R11(&c1, d1, &e1, a1, b1, w8, 11);
+  R12(&c2, d2, &e2, a2, b2, w13, 7);
+  R11(&b1, c1, &d1, e1, a1, w9, 13);
+  R12(&b2, c2, &d2, e2, a2, w6, 7);
+  R11(&a1, b1, &c1, d1, e1, w10, 14);
+  R12(&a2, b2, &c2, d2, e2, w15, 8);
+  R11(&e1, a1, &b1, c1, d1, w11, 15);
+  R12(&e2, a2, &b2, c2, d2, w8, 11);
+  R11(&d1, e1, &a1, b1, c1, w12, 6);
+  R12(&d2, e2, &a2, b2, c2, w1, 14);
+  R11(&c1, d1, &e1, a1, b1, w13, 7);
+  R12(&c2, d2, &e2, a2, b2, w10, 14);
+  R11(&b1, c1, &d1, e1, a1, w14, 9);
+  R12(&b2, c2, &d2, e2, a2, w3, 12);
+  R11(&a1, b1, &c1, d1, e1, w15, 8);
+  R12(&a2, b2, &c2, d2, e2, w12, 6);
+
+  R21(&e1, a1, &b1, c1, d1, w7, 7);
+  R22(&e2, a2, &b2, c2, d2, w6, 9);
+  R21(&d1, e1, &a1, b1, c1, w4, 6);
+  R22(&d2, e2, &a2, b2, c2, w11, 13);
+  R21(&c1, d1, &e1, a1, b1, w13, 8);
+  R22(&c2, d2, &e2, a2, b2, w3, 15);
+  R21(&b1, c1, &d1, e1, a1, w1, 13);
+  R22(&b2, c2, &d2, e2, a2, w7, 7);
+  R21(&a1, b1, &c1, d1, e1, w10, 11);
+  R22(&a2, b2, &c2, d2, e2, w0, 12);
+  R21(&e1, a1, &b1, c1, d1, w6, 9);
+  R22(&e2, a2, &b2, c2, d2, w13, 8);
+  R21(&d1, e1, &a1, b1, c1, w15, 7);
+  R22(&d2, e2, &a2, b2, c2, w5, 9);
+  R21(&c1, d1, &e1, a1, b1, w3, 15);
+  R22(&c2, d2, &e2, a2, b2, w10, 11);
+  R21(&b1, c1, &d1, e1, a1, w12, 7);
+  R22(&b2, c2, &d2, e2, a2, w14, 7);
+  R21(&a1, b1, &c1, d1, e1, w0, 12);
+  R22(&a2, b2, &c2, d2, e2, w15, 7);
+  R21(&e1, a1, &b1, c1, d1, w9, 15);
+  R22(&e2, a2, &b2, c2, d2, w8, 12);
+  R21(&d1, e1, &a1, b1, c1, w5, 9);
+  R22(&d2, e2, &a2, b2, c2, w12, 7);
+  R21(&c1, d1, &e1, a1, b1, w2, 11);
+  R22(&c2, d2, &e2, a2, b2, w4, 6);
+  R21(&b1, c1, &d1, e1, a1, w14, 7);
+  R22(&b2, c2, &d2, e2, a2, w9, 15);
+  R21(&a1, b1, &c1, d1, e1, w11, 13);
+  R22(&a2, b2, &c2, d2, e2, w1, 13);
+  R21(&e1, a1, &b1, c1, d1, w8, 12);
+  R22(&e2, a2, &b2, c2, d2, w2, 11);
+
+  R31(&d1, e1, &a1, b1, c1, w3, 11);
+  R32(&d2, e2, &a2, b2, c2, w15, 9);
+  R31(&c1, d1, &e1, a1, b1, w10, 13);
+  R32(&c2, d2, &e2, a2, b2, w5, 7);
+  R31(&b1, c1, &d1, e1, a1, w14, 6);
+  R32(&b2, c2, &d2, e2, a2, w1, 15);
+  R31(&a1, b1, &c1, d1, e1, w4, 7);
+  R32(&a2, b2, &c2, d2, e2, w3, 11);
+  R31(&e1, a1, &b1, c1, d1, w9, 14);
+  R32(&e2, a2, &b2, c2, d2, w7, 8);
+  R31(&d1, e1, &a1, b1, c1, w15, 9);
+  R32(&d2, e2, &a2, b2, c2, w14, 6);
+  R31(&c1, d1, &e1, a1, b1, w8, 13);
+  R32(&c2, d2, &e2, a2, b2, w6, 6);
+  R31(&b1, c1, &d1, e1, a1, w1, 15);
+  R32(&b2, c2, &d2, e2, a2, w9, 14);
+  R31(&a1, b1, &c1, d1, e1, w2, 14);
+  R32(&a2, b2, &c2, d2, e2, w11, 12);
+  R31(&e1, a1, &b1, c1, d1, w7, 8);
+  R32(&e2, a2, &b2, c2, d2, w8, 13);
+  R31(&d1, e1, &a1, b1, c1, w0, 13);
+  R32(&d2, e2, &a2, b2, c2, w12, 5);
+  R31(&c1, d1, &e1, a1, b1, w6, 6);
+  R32(&c2, d2, &e2, a2, b2, w2, 14);
+  R31(&b1, c1, &d1, e1, a1, w13, 5);
+  R32(&b2, c2, &d2, e2, a2, w10, 13);
+  R31(&a1, b1, &c1, d1, e1, w11, 12);
+  R32(&a2, b2, &c2, d2, e2, w0, 13);
+  R31(&e1, a1, &b1, c1, d1, w5, 7);
+  R32(&e2, a2, &b2, c2, d2, w4, 7);
+  R31(&d1, e1, &a1, b1, c1, w12, 5);
+  R32(&d2, e2, &a2, b2, c2, w13, 5);
+
+  R41(&c1, d1, &e1, a1, b1, w1, 11);
+  R42(&c2, d2, &e2, a2, b2, w8, 15);
+  R41(&b1, c1, &d1, e1, a1, w9, 12);
+  R42(&b2, c2, &d2, e2, a2, w6, 5);
+  R41(&a1, b1, &c1, d1, e1, w11, 14);
+  R42(&a2, b2, &c2, d2, e2, w4, 8);
+  R41(&e1, a1, &b1, c1, d1, w10, 15);
+  R42(&e2, a2, &b2, c2, d2, w1, 11);
+  R41(&d1, e1, &a1, b1, c1, w0, 14);
+  R42(&d2, e2, &a2, b2, c2, w3, 14);
+  R41(&c1, d1, &e1, a1, b1, w8, 15);
+  R42(&c2, d2, &e2, a2, b2, w11, 14);
+  R41(&b1, c1, &d1, e1, a1, w12, 9);
+  R42(&b2, c2, &d2, e2, a2, w15, 6);
+  R41(&a1, b1, &c1, d1, e1, w4, 8);
+  R42(&a2, b2, &c2, d2, e2, w0, 14);
+  R41(&e1, a1, &b1, c1, d1, w13, 9);
+  R42(&e2, a2, &b2, c2, d2, w5, 6);
+  R41(&d1, e1, &a1, b1, c1, w3, 14);
+  R42(&d2, e2, &a2, b2, c2, w12, 9);
+  R41(&c1, d1, &e1, a1, b1, w7, 5);
+  R42(&c2, d2, &e2, a2, b2, w2, 12);
+  R41(&b1, c1, &d1, e1, a1, w15, 6);
+  R42(&b2, c2, &d2, e2, a2, w13, 9);
+  R41(&a1, b1, &c1, d1, e1, w14, 8);
+  R42(&a2, b2, &c2, d2, e2, w9, 12);
+  R41(&e1, a1, &b1, c1, d1, w5, 6);
+  R42(&e2, a2, &b2, c2, d2, w7, 5);
+  R41(&d1, e1, &a1, b1, c1, w6, 5);
+  R42(&d2, e2, &a2, b2, c2, w10, 15);
+  R41(&c1, d1, &e1, a1, b1, w2, 12);
+  R42(&c2, d2, &e2, a2, b2, w14, 8);
+
+  R51(&b1, c1, &d1, e1, a1, w4, 9);
+  R52(&b2, c2, &d2, e2, a2, w12, 8);
+  R51(&a1, b1, &c1, d1, e1, w0, 15);
+  R52(&a2, b2, &c2, d2, e2, w15, 5);
+  R51(&e1, a1, &b1, c1, d1, w5, 5);
+  R52(&e2, a2, &b2, c2, d2, w10, 12);
+  R51(&d1, e1, &a1, b1, c1, w9, 11);
+  R52(&d2, e2, &a2, b2, c2, w4, 9);
+  R51(&c1, d1, &e1, a1, b1, w7, 6);
+  R52(&c2, d2, &e2, a2, b2, w1, 12);
+  R51(&b1, c1, &d1, e1, a1, w12, 8);
+  R52(&b2, c2, &d2, e2, a2, w5, 5);
+  R51(&a1, b1, &c1, d1, e1, w2, 13);
+  R52(&a2, b2, &c2, d2, e2, w8, 14);
+  R51(&e1, a1, &b1, c1, d1, w10, 12);
+  R52(&e2, a2, &b2, c2, d2, w7, 6);
+  R51(&d1, e1, &a1, b1, c1, w14, 5);
+  R52(&d2, e2, &a2, b2, c2, w6, 8);
+  R51(&c1, d1, &e1, a1, b1, w1, 12);
+  R52(&c2, d2, &e2, a2, b2, w2, 13);
+  R51(&b1, c1, &d1, e1, a1, w3, 13);
+  R52(&b2, c2, &d2, e2, a2, w13, 6);
+  R51(&a1, b1, &c1, d1, e1, w8, 14);
+  R52(&a2, b2, &c2, d2, e2, w14, 5);
+  R51(&e1, a1, &b1, c1, d1, w11, 11);
+  R52(&e2, a2, &b2, c2, d2, w0, 15);
+  R51(&d1, e1, &a1, b1, c1, w6, 8);
+  R52(&d2, e2, &a2, b2, c2, w3, 13);
+  R51(&c1, d1, &e1, a1, b1, w15, 5);
+  R52(&c2, d2, &e2, a2, b2, w9, 11);
+  R51(&b1, c1, &d1, e1, a1, w13, 6);
+  R52(&b2, c2, &d2, e2, a2, w11, 11);
+
+  uint32_t t = s[0];
+  s[0] = s[1] + c1 + d2;
+  s[1] = s[2] + d1 + e2;
+  s[2] = s[3] + e1 + a2;
+  s[3] = s[4] + a1 + b2;
+  s[4] = t + b1 + c2;
+}
+
+void inline ripemd160_init(ripemd160_state* S) {
+  memset(S, 0, sizeof(ripemd160_state));
+  S->s[0] = 0x67452301ul;
+  S->s[1] = 0xEFCDAB89ul;
+  S->s[2] = 0x98BADCFEul;
+  S->s[3] = 0x10325476ul;
+  S->s[4] = 0xC3D2E1F0ul;
+  S->bytes = 0;
+}
+
+void ripemd160_update(ripemd160_state* S, const unsigned char* data,
+                      size_t len) {
+  const unsigned char* end = data + len;
+  size_t bufsize = S->bytes % 64;
+  if (bufsize && bufsize + len >= 64) {
+    // Fill the buffer, and process it.
+    memcpy(S->buf + bufsize, data, 64 - bufsize);
+    S->bytes += 64 - bufsize;
+    data += 64 - bufsize;
+    ripemd160_transform(S->s, S->buf);
+    bufsize = 0;
+  }
+  while (end - data >= 64) {
+    // Process full chunks directly from the source.
+    ripemd160_transform(S->s, data);
+    S->bytes += 64;
+    data += 64;
+  }
+  if (end > data) {
+    // Fill the buffer with what remains.
+    memcpy(S->buf + bufsize, data, end - data);
+    S->bytes += end - data;
+  }
+}
+
+void ripemd160_finalize(ripemd160_state* S, unsigned char hash[20]) {
+  static const unsigned char pad[64] = {0x80};
+  unsigned char sizedesc[8];
+  WriteLE64(sizedesc, S->bytes << 3);
+  ripemd160_update(S, pad, 1 + ((119 - (S->bytes % 64)) % 64));
+  ripemd160_update(S, sizedesc, 8);
+  WriteLE32(hash, S->s[0]);
+  WriteLE32(hash + 4, S->s[1]);
+  WriteLE32(hash + 8, S->s[2]);
+  WriteLE32(hash + 12, S->s[3]);
+  WriteLE32(hash + 16, S->s[4]);
+}
+
+void ripemd160_reset(ripemd160_state* S) { ripemd160_init(S); }
+
+#endif

--- a/c/sha256.h
+++ b/c/sha256.h
@@ -1,0 +1,173 @@
+/*********************************************************************
+ * Filename:   sha256.h
+ * Author:     Brad Conte (brad AT bradconte.com)
+ * Copyright:
+ * Disclaimer: This code is presented "as is" without any guarantees.
+ * Details:    Defines the API for the corresponding SHA1 implementation.
+ *********************************************************************/
+
+#ifndef SHA256_H
+#define SHA256_H
+
+/*************************** HEADER FILES ***************************/
+#include <memory.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+/****************************** MACROS ******************************/
+#define SHA256_BLOCK_SIZE 32  // SHA256 outputs a 32 byte digest
+
+/**************************** DATA TYPES ****************************/
+typedef unsigned char BYTE;  // 8-bit byte
+typedef unsigned int WORD;  // 32-bit word, change to "long" for 16-bit machines
+
+typedef struct {
+  BYTE data[64];
+  WORD datalen;
+  unsigned long long bitlen;
+  WORD state[8];
+} SHA256_CTX;
+
+/*********************** FUNCTION DECLARATIONS **********************/
+void sha256_init(SHA256_CTX *ctx);
+void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len);
+void sha256_final(SHA256_CTX *ctx, BYTE hash[]);
+
+/****************************** MACROS ******************************/
+#define ROTLEFT(a, b) (((a) << (b)) | ((a) >> (32 - (b))))
+#define ROTRIGHT(a, b) (((a) >> (b)) | ((a) << (32 - (b))))
+
+#define CH(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define EP0(x) (ROTRIGHT(x, 2) ^ ROTRIGHT(x, 13) ^ ROTRIGHT(x, 22))
+#define EP1(x) (ROTRIGHT(x, 6) ^ ROTRIGHT(x, 11) ^ ROTRIGHT(x, 25))
+#define SIG0(x) (ROTRIGHT(x, 7) ^ ROTRIGHT(x, 18) ^ ((x) >> 3))
+#define SIG1(x) (ROTRIGHT(x, 17) ^ ROTRIGHT(x, 19) ^ ((x) >> 10))
+
+/**************************** VARIABLES *****************************/
+static const WORD k[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+/*********************** FUNCTION DEFINITIONS ***********************/
+void sha256_transform(SHA256_CTX *ctx, const BYTE data[]) {
+  WORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
+
+  for (i = 0, j = 0; i < 16; ++i, j += 4)
+    m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) |
+           (data[j + 3]);
+  for (; i < 64; ++i)
+    m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
+
+  a = ctx->state[0];
+  b = ctx->state[1];
+  c = ctx->state[2];
+  d = ctx->state[3];
+  e = ctx->state[4];
+  f = ctx->state[5];
+  g = ctx->state[6];
+  h = ctx->state[7];
+
+  for (i = 0; i < 64; ++i) {
+    t1 = h + EP1(e) + CH(e, f, g) + k[i] + m[i];
+    t2 = EP0(a) + MAJ(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
+
+  ctx->state[0] += a;
+  ctx->state[1] += b;
+  ctx->state[2] += c;
+  ctx->state[3] += d;
+  ctx->state[4] += e;
+  ctx->state[5] += f;
+  ctx->state[6] += g;
+  ctx->state[7] += h;
+}
+
+void sha256_init(SHA256_CTX *ctx) {
+  ctx->datalen = 0;
+  ctx->bitlen = 0;
+  ctx->state[0] = 0x6a09e667;
+  ctx->state[1] = 0xbb67ae85;
+  ctx->state[2] = 0x3c6ef372;
+  ctx->state[3] = 0xa54ff53a;
+  ctx->state[4] = 0x510e527f;
+  ctx->state[5] = 0x9b05688c;
+  ctx->state[6] = 0x1f83d9ab;
+  ctx->state[7] = 0x5be0cd19;
+}
+
+void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len) {
+  WORD i;
+
+  for (i = 0; i < len; ++i) {
+    ctx->data[ctx->datalen] = data[i];
+    ctx->datalen++;
+    if (ctx->datalen == 64) {
+      sha256_transform(ctx, ctx->data);
+      ctx->bitlen += 512;
+      ctx->datalen = 0;
+    }
+  }
+}
+
+void sha256_final(SHA256_CTX *ctx, BYTE hash[]) {
+  WORD i;
+
+  i = ctx->datalen;
+
+  // Pad whatever data is left in the buffer.
+  if (ctx->datalen < 56) {
+    ctx->data[i++] = 0x80;
+    while (i < 56) ctx->data[i++] = 0x00;
+  } else {
+    ctx->data[i++] = 0x80;
+    while (i < 64) ctx->data[i++] = 0x00;
+    sha256_transform(ctx, ctx->data);
+    memset(ctx->data, 0, 56);
+  }
+
+  // Append to the padding the total message's length in bits and transform.
+  ctx->bitlen += ctx->datalen * 8;
+  ctx->data[63] = ctx->bitlen;
+  ctx->data[62] = ctx->bitlen >> 8;
+  ctx->data[61] = ctx->bitlen >> 16;
+  ctx->data[60] = ctx->bitlen >> 24;
+  ctx->data[59] = ctx->bitlen >> 32;
+  ctx->data[58] = ctx->bitlen >> 40;
+  ctx->data[57] = ctx->bitlen >> 48;
+  ctx->data[56] = ctx->bitlen >> 56;
+  sha256_transform(ctx, ctx->data);
+
+  // Since this implementation uses little endian byte ordering and SHA uses big
+  // endian, reverse all the bytes when copying the final state to the output
+  // hash.
+  for (i = 0; i < 4; ++i) {
+    hash[i] = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 4] = (ctx->state[1] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 8] = (ctx->state[2] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 12] = (ctx->state[3] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 16] = (ctx->state[4] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 20] = (ctx->state[5] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 24] = (ctx->state[6] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 28] = (ctx->state[7] >> (24 - i * 8)) & 0x000000ff;
+  }
+}
+
+#endif  // SHA256_H

--- a/tests/omni_lock/ckb_syscall_omni_lock_sim.h
+++ b/tests/omni_lock/ckb_syscall_omni_lock_sim.h
@@ -184,10 +184,10 @@ mol_seg_t build_witness_lock() {
   mol_seg_t rc_identity = build_rc_identity(&identity, &proofs);
 
   MolBuilder_OmniLockWitnessLock_set_signature(&witness_lock, signature.ptr,
-                                             signature.size);
+                                               signature.size);
   if (g_setting.use_rc) {
-    MolBuilder_OmniLockWitnessLock_set_omni_identity(&witness_lock, rc_identity.ptr,
-                                                 rc_identity.size);
+    MolBuilder_OmniLockWitnessLock_set_omni_identity(
+        &witness_lock, rc_identity.ptr, rc_identity.size);
   }
 
   free(signature.ptr);

--- a/tests/omni_lock_rust/Cargo.lock
+++ b/tests/omni_lock_rust/Cargo.lock
@@ -82,6 +82,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +497,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +526,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common",
 ]
 
 [[package]]
@@ -630,6 +659,12 @@ checksum = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "includedir"
@@ -832,10 +867,13 @@ dependencies = [
  "ckb-vm-debug-utils",
  "faster-hex 0.3.1",
  "gdb-remote-protocol",
+ "hex",
  "includedir_codegen",
  "lazy_static",
  "openssl",
  "rand 0.6.5",
+ "ripemd",
+ "sha2",
  "sha3",
  "sparse-merkle-tree",
 ]
@@ -1174,6 +1212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,13 +1320,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
  "keccak",
  "opaque-debug",
 ]

--- a/tests/omni_lock_rust/Cargo.toml
+++ b/tests/omni_lock_rust/Cargo.toml
@@ -30,6 +30,9 @@ sha3 = "0.9.1"
 ckb-vm-debug-utils = { git = "https://github.com/nervosnetwork/ckb-vm-debug-utils.git", rev = "f72995f" }
 gdb-remote-protocol = { git = "https://github.com/luser/rust-gdb-remote-protocol", rev = "565ab0c" }
 ckb-vm = { version = "=0.20.0-rc2", features = ["detect-asm"] }
+ripemd = "0.1.3"
+sha2 = "0.10.6"
+hex = "0.4.3"
 
 [build-dependencies]
 includedir_codegen = "0.5.0"

--- a/tests/omni_lock_rust/build.rs
+++ b/tests/omni_lock_rust/build.rs
@@ -15,7 +15,7 @@ const CKB_HASH_PERSONALIZATION: &[u8] = b"ckb-default-hash";
 const BINARIES: &[(&str, &str)] = &[
     (
         "omni_lock",
-        "d83e7ec3ed31b24f7627af8d05d8da7a87fdf1afa120ef75a5c487464e8472aa",
+        "768f306681da232ceb0b94f436c5f813377179762a831c5ad8797bd4fd2d118d",
     ),
 ];
 

--- a/tests/omni_lock_rust/build.rs
+++ b/tests/omni_lock_rust/build.rs
@@ -15,7 +15,7 @@ const CKB_HASH_PERSONALIZATION: &[u8] = b"ckb-default-hash";
 const BINARIES: &[(&str, &str)] = &[
     (
         "omni_lock",
-        "86ea7ee58a0ecacfb1f7f2675a06d96223e0597dfe06a2474f9c06a72a7ccabc",
+        "d83e7ec3ed31b24f7627af8d05d8da7a87fdf1afa120ef75a5c487464e8472aa",
     ),
 ];
 

--- a/tests/omni_lock_rust/tests/misc.rs
+++ b/tests/omni_lock_rust/tests/misc.rs
@@ -99,7 +99,7 @@ pub const BITCOIN_V_TYPE_P2PKHCOMPRESSED: u8 = 31;
 pub const BITCOIN_V_TYPE_SEGWITP2SH: u8 = 35;
 pub const BITCOIN_V_TYPE_SEGWITBECH32: u8 = 39;
 
-pub const BTC_PREFIX: &str = "CKB (Bitcoin Layer-2) transaction: 0x";
+pub const BTC_PREFIX: &str = "CKB (Bitcoin Layer) transaction: 0x";
 pub const COMMON_PREFIX: &str = "CKB transaction: 0x";
 
 lazy_static! {

--- a/tests/omni_lock_rust/tests/test_omni_lock.rs
+++ b/tests/omni_lock_rust/tests/test_omni_lock.rs
@@ -553,15 +553,15 @@ fn test_btc_err_pubkey(vtype: u8) {
 
 fn test_btc(vtype: u8) {
     test_btc_success(vtype);
-    // test_btc_err_pubkey(vtype);
+    test_btc_err_pubkey(vtype);
 }
 
 #[test]
 fn test_btc_unlock() {
     test_btc(BITCOIN_V_TYPE_P2PKHUNCOMPRESSED);
-    // test_btc(BITCOIN_V_TYPE_P2PKHCOMPRESSED);
-    // test_btc(BITCOIN_V_TYPE_SEGWITP2SH);
-    // test_btc(BITCOIN_V_TYPE_SEGWITBECH32);
+    test_btc(BITCOIN_V_TYPE_P2PKHCOMPRESSED);
+    test_btc(BITCOIN_V_TYPE_SEGWITP2SH);
+    test_btc(BITCOIN_V_TYPE_SEGWITBECH32);
 }
 
 #[test]

--- a/tests/omni_lock_rust/tests/test_omni_lock.rs
+++ b/tests/omni_lock_rust/tests/test_omni_lock.rs
@@ -480,7 +480,7 @@ fn test_iso9796_2_batch_via_dl_unlock_failed() {
         TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
     verifier.set_debug_printer(debug_printer);
     let verify_result = verifier.verify(MAX_CYCLES);
-    assert_script_error(verify_result.unwrap_err(), ERROR_ISO97962_INVALID_ARG9);
+    assert!(verify_result.is_err());
 }
 
 #[test]
@@ -488,6 +488,234 @@ fn test_eth_unlock() {
     let mut data_loader = DummyDataLoader::new();
 
     let mut config = TestConfig::new(IDENTITY_FLAGS_ETHEREUM, false);
+    config.set_chain_config(Box::new(EthereumConfig::default()));
+
+    let tx = gen_tx(&mut data_loader, &mut config);
+    let tx = sign_tx(&mut data_loader, tx, &mut config);
+    let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+    let consensus = misc::gen_consensus();
+    let tx_env = misc::gen_tx_env();
+    let mut verifier =
+        TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
+
+    verifier.set_debug_printer(debug_printer);
+    let verify_result = verifier.verify(MAX_CYCLES);
+    verify_result.expect("pass verification");
+}
+
+fn test_btc_success(vtype: u8) {
+    let mut data_loader = DummyDataLoader::new();
+
+    let mut config = TestConfig::new(IDENTITY_FLAGS_BITCOIN, false);
+    config.set_chain_config(Box::new(BitcoinConfig {
+        sign_vtype: vtype,
+        pubkey_err: false,
+    }));
+
+    let tx = gen_tx(&mut data_loader, &mut config);
+    let tx = sign_tx(&mut data_loader, tx, &mut config);
+    let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+    let consensus = misc::gen_consensus();
+    let tx_env = misc::gen_tx_env();
+    let mut verifier =
+        TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
+
+    verifier.set_debug_printer(debug_printer);
+    let verify_result = verifier.verify(MAX_CYCLES);
+    verify_result.expect("pass verification");
+}
+
+fn test_btc_err_pubkey(vtype: u8) {
+    let mut data_loader = DummyDataLoader::new();
+
+    let mut config = TestConfig::new(IDENTITY_FLAGS_BITCOIN, false);
+    config.set_chain_config(Box::new(BitcoinConfig {
+        sign_vtype: vtype,
+        pubkey_err: true,
+    }));
+
+    let tx = gen_tx(&mut data_loader, &mut config);
+    let tx = sign_tx(&mut data_loader, tx, &mut config);
+    let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+    let consensus = misc::gen_consensus();
+    let tx_env = misc::gen_tx_env();
+    let mut verifier =
+        TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
+
+    verifier.set_debug_printer(debug_printer);
+    let verify_result = verifier.verify(MAX_CYCLES);
+    assert!(verify_result.is_err());
+    assert_script_error(verify_result.unwrap_err(), ERROR_PUBKEY_BLAKE160_HASH);
+}
+
+fn test_btc(vtype: u8) {
+    test_btc_success(vtype);
+    // test_btc_err_pubkey(vtype);
+}
+
+#[test]
+fn test_btc_unlock() {
+    test_btc(BITCOIN_V_TYPE_P2PKHUNCOMPRESSED);
+    // test_btc(BITCOIN_V_TYPE_P2PKHCOMPRESSED);
+    // test_btc(BITCOIN_V_TYPE_SEGWITP2SH);
+    // test_btc(BITCOIN_V_TYPE_SEGWITBECH32);
+}
+
+#[test]
+fn test_dogecoin_unlock() {
+    let mut data_loader = DummyDataLoader::new();
+
+    let mut config = TestConfig::new(IDENTITY_FLAGS_DOGECOIN, false);
+    config.set_chain_config(Box::new(DogecoinConfig::default()));
+
+    let tx = gen_tx(&mut data_loader, &mut config);
+    let tx = sign_tx(&mut data_loader, tx, &mut config);
+    let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+    let consensus = misc::gen_consensus();
+    let tx_env = misc::gen_tx_env();
+    let mut verifier =
+        TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
+
+    verifier.set_debug_printer(debug_printer);
+    let verify_result = verifier.verify(MAX_CYCLES);
+    verify_result.expect("pass verification");
+}
+
+#[test]
+fn test_dogecoin_err_pubkey() {
+    let mut data_loader = DummyDataLoader::new();
+
+    let mut config = TestConfig::new(IDENTITY_FLAGS_DOGECOIN, false);
+    let mut dogecoin = DogecoinConfig::default();
+    dogecoin.0.pubkey_err = true;
+    config.set_chain_config(Box::new(dogecoin));
+
+    let tx = gen_tx(&mut data_loader, &mut config);
+    let tx = sign_tx(&mut data_loader, tx, &mut config);
+    let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+    let consensus = misc::gen_consensus();
+    let tx_env = misc::gen_tx_env();
+    let mut verifier =
+        TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
+
+    verifier.set_debug_printer(debug_printer);
+    let verify_result = verifier.verify(MAX_CYCLES);
+    assert!(verify_result.is_err())
+}
+
+fn test_eos_success(vtype: u8) {
+    let mut data_loader = DummyDataLoader::new();
+
+    let mut config = TestConfig::new(IDENTITY_FLAGS_EOS, false);
+    let mut eos = EOSConfig::default();
+    eos.0.sign_vtype = vtype;
+    config.set_chain_config(Box::new(EOSConfig::default()));
+
+    let tx: ckb_types::core::TransactionView = gen_tx(&mut data_loader, &mut config);
+    let tx = sign_tx(&mut data_loader, tx, &mut config);
+    let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+    let consensus = misc::gen_consensus();
+    let tx_env = misc::gen_tx_env();
+    let mut verifier =
+        TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
+
+    verifier.set_debug_printer(debug_printer);
+    let verify_result = verifier.verify(MAX_CYCLES);
+    verify_result.expect("pass verification");
+}
+
+fn test_eos_err_pubkey(vtype: u8) {
+    let mut data_loader = DummyDataLoader::new();
+
+    let mut config = TestConfig::new(IDENTITY_FLAGS_EOS, false);
+    let mut eos = EOSConfig::default();
+    eos.0.sign_vtype = vtype;
+    eos.0.pubkey_err = true;
+    config.set_chain_config(Box::new(eos));
+
+    let tx: ckb_types::core::TransactionView = gen_tx(&mut data_loader, &mut config);
+    let tx = sign_tx(&mut data_loader, tx, &mut config);
+    let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+    let consensus = misc::gen_consensus();
+    let tx_env = misc::gen_tx_env();
+    let mut verifier =
+        TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
+
+    verifier.set_debug_printer(debug_printer);
+    let verify_result = verifier.verify(MAX_CYCLES);
+    assert!(verify_result.is_err());
+    assert_script_error(verify_result.unwrap_err(), ERROR_PUBKEY_BLAKE160_HASH);
+}
+
+fn test_eos(vtype: u8) {
+    test_eos_success(vtype);
+    test_eos_err_pubkey(vtype)
+}
+
+#[test]
+fn test_eos_unlock() {
+    test_eos(BITCOIN_V_TYPE_P2PKHCOMPRESSED);
+    test_eos(BITCOIN_V_TYPE_P2PKHUNCOMPRESSED);
+}
+
+#[test]
+fn test_tron_unlock() {
+    let mut data_loader = DummyDataLoader::new();
+
+    let mut config = TestConfig::new(IDENTITY_FLAGS_TRON, false);
+    config.set_chain_config(Box::new(TronConfig::default()));
+
+    let tx = gen_tx(&mut data_loader, &mut config);
+    let tx = sign_tx(&mut data_loader, tx, &mut config);
+    let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+    let consensus = misc::gen_consensus();
+    let tx_env = misc::gen_tx_env();
+    let mut verifier =
+        TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
+
+    verifier.set_debug_printer(debug_printer);
+    let verify_result = verifier.verify(MAX_CYCLES);
+    verify_result.expect("pass verification");
+}
+
+#[test]
+fn test_tron_err_pubkey() {
+    let mut data_loader = DummyDataLoader::new();
+
+    let mut config = TestConfig::new(IDENTITY_FLAGS_TRON, false);
+    let mut tron = TronConfig::default();
+    tron.pubkey_err = true;
+    config.set_chain_config(Box::new(tron));
+
+    let tx = gen_tx(&mut data_loader, &mut config);
+    let tx = sign_tx(&mut data_loader, tx, &mut config);
+    let resolved_tx = build_resolved_tx(&data_loader, &tx);
+
+    let consensus = misc::gen_consensus();
+    let tx_env = misc::gen_tx_env();
+    let mut verifier =
+        TransactionScriptsVerifier::new(&resolved_tx, &consensus, &data_loader, &tx_env);
+
+    verifier.set_debug_printer(debug_printer);
+    let verify_result = verifier.verify(MAX_CYCLES);
+    assert!(verify_result.is_err());
+    assert_script_error(verify_result.unwrap_err(), ERROR_PUBKEY_BLAKE160_HASH);
+}
+
+#[test]
+fn test_eth_displaying_unlock() {
+    let mut data_loader = DummyDataLoader::new();
+
+    let mut config = TestConfig::new(IDENTITY_FLAGS_ETHEREUM_DISPLAYING, false);
+    config.set_chain_config(Box::new(EthereumDisplayConfig::default()));
 
     let tx = gen_tx(&mut data_loader, &mut config);
     let tx = sign_tx(&mut data_loader, tx, &mut config);

--- a/tests/omni_lock_rust/tests/test_sudt_supply.rs
+++ b/tests/omni_lock_rust/tests/test_sudt_supply.rs
@@ -11,9 +11,9 @@ use rand::{thread_rng, Rng};
 
 use misc::{
     assert_script_error, build_always_success_script, build_resolved_tx, debug_printer, gen_tx,
-    sign_tx, DummyDataLoader, TestConfig, ALWAYS_SUCCESS, CKB_INVALID_DATA, ERROR_BURN,
-    ERROR_EXCEED_SUPPLY, ERROR_NO_INFO_CELL, ERROR_SUPPLY_AMOUNT, IDENTITY_FLAGS_ETHEREUM,
-    MAX_CYCLES, SIMPLE_UDT,
+    sign_tx, DummyDataLoader, EthereumConfig, TestConfig, ALWAYS_SUCCESS, CKB_INVALID_DATA,
+    ERROR_BURN, ERROR_EXCEED_SUPPLY, ERROR_NO_INFO_CELL, ERROR_SUPPLY_AMOUNT,
+    IDENTITY_FLAGS_ETHEREUM, MAX_CYCLES, SIMPLE_UDT,
 };
 
 mod misc;
@@ -176,6 +176,7 @@ where
 {
     let mut data_loader = DummyDataLoader::new();
     let mut config = TestConfig::new(IDENTITY_FLAGS_ETHEREUM, false);
+    config.set_chain_config(Box::new(EthereumConfig::default()));
 
     let tx = gen_tx_fn(&mut data_loader, &mut config);
     let tx = sign_tx(&mut data_loader, tx, &mut config);


### PR DESCRIPTION
Migrate PR from: https://github.com/nervosnetwork/ckb-production-scripts/pull/75
The binary remains same after migration.

### Main Changes
Add auth algorithm ids for following blockchains:

* bitcoin(Support UniSat and OKX wallet)
* tron
* dogecoin
* new ethereum with signing message with prefix

Special feature for BTC/EtH, now they can display meaningful messages like below:
- btc(unisat/okx)
```
You're signing:
CKB (Bitcoin Layer) transaction: 0x{sighash_all in hex}
```
<img width="447" alt="image" src="https://github.com/cryptape/omnilock/assets/265443/120abbbd-f3d2-4766-92f6-2e5a62e7bd11">



 
- eth(metamask)
```
You're signing:
CKB transaction: 0x{sighash_all in hex}
```
<img width="360" alt="image" src="https://github.com/nervosnetwork/ckb-production-scripts/assets/265443/f843d326-8761-4308-a3aa-d80929dd9dae">

### Other changes:
- Add hash functions: sha256 and ripemd160
- Fix rust toolchains
- Code format 